### PR TITLE
fix:surrealql file extension

### DIFF
--- a/lua/tree-sitter-surrealdb/init.lua
+++ b/lua/tree-sitter-surrealdb/init.lua
@@ -2,6 +2,7 @@ local function setup()
     vim.filetype.add({
         extension = {
             surql = "surql",
+            surrealql = "surql"
         }
     });
 

--- a/lua/tree-sitter-surrealdb/init.lua
+++ b/lua/tree-sitter-surrealdb/init.lua
@@ -1,9 +1,9 @@
 local function setup()
-	vim.api.nvim_command([[
-	augroup SurqlFiletype
-	  autocmd BufRead,BufNewFile *.surql :set filetype=surql
-	augroup END
-	]])
+    vim.filetype.add({
+        extension = {
+            surql = "surql",
+        }
+    });
 
 	local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
 	parser_config.surrealdb = {

--- a/lua/tree-sitter-surrealdb/init.lua
+++ b/lua/tree-sitter-surrealdb/init.lua
@@ -1,10 +1,10 @@
 local function setup()
-    vim.filetype.add({
-        extension = {
-            surql = "surql",
-            surrealql = "surql"
-        }
-    });
+	vim.filetype.add({
+	    extension = {
+	        surql = "surql",
+	        surrealql = "surql"
+	    }
+	});
 
 	local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
 	parser_config.surrealdb = {


### PR DESCRIPTION
Adds `*.surrealql` to the supported file extensions.
Includes small refactor to use native Lua function to add the file types.