### PR TITLE
refactor:cache folder for queries

### DIFF
--- a/lua/tree-sitter-surrealdb/init.lua
+++ b/lua/tree-sitter-surrealdb/init.lua
@@ -41,7 +41,8 @@ local function setup()
 	(scripting_content) @javascript
 	]]
 
-	local runtime_path = vim.api.nvim_list_runtime_paths()[1]
+	local runtime_path = vim.fn.stdpath("cache")
+	vim.opt.runtimepath:append(runtime_path)
 	vim.fn.mkdir(runtime_path .. "/queries/surrealdb", "p")
 
 	if vim.fn.isdirectory(runtime_path .. "/queries/surrealdb") == 1 then

--- a/lua/tree-sitter-surrealdb/init.lua
+++ b/lua/tree-sitter-surrealdb/init.lua
@@ -42,12 +42,7 @@ local function setup()
 	]]
 
 	local runtime_path = vim.api.nvim_list_runtime_paths()[1]
-	if vim.fn.isdirectory(runtime_path .. "/queries") == 0 then
-		vim.fn.mkdir(runtime_path .. "/queries")
-	end
-	if vim.fn.isdirectory(runtime_path .. "/queries/surrealdb") == 0 then
-		vim.fn.mkdir(runtime_path .. "/queries/surrealdb")
-	end
+	vim.fn.mkdir(runtime_path .. "/queries/surrealdb", "p")
 
 	if vim.fn.isdirectory(runtime_path .. "/queries/surrealdb") == 1 then
 		local highlights_file = io.open(runtime_path .. "/queries/surrealdb/highlights.scm", "w")


### PR DESCRIPTION
Changes the runtime folder used to the cache folder.
This makes the plugin compatible with immutable systems such as NixOS (tested on that one).