### PR TITLE
fix: highlighting

### DIFF
--- a/lua/tree-sitter-surrealdb/init.lua
+++ b/lua/tree-sitter-surrealdb/init.lua
@@ -31,7 +31,7 @@ local function setup()
 	(record) @type
 	(function) @function
 	(property) @field
-	(identifier) @constant @text.emphasis (#set! "priority" 120)
+	(identifier) @text.emphasis
 	(casting) @conceal
 	(duration) @number
 	(type) @type


### PR DESCRIPTION
identifiers are now in the color of @text.emphasis